### PR TITLE
nix for both linux and macox

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677321029,
-        "narHash": "sha256-Jvgm3LSpxAL5KDyHMOub8G6f+6dl7X8YTXsRSPAtiXw=",
+        "lastModified": 1718225733,
+        "narHash": "sha256-aTIpfLT+hQr0H1d7QA2k5a5rWrkL+M8ECN2tI9ClpSg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "38b7104fd1db0046ceed579f5dab4e62f136589c",
+        "rev": "a9858885e197f984d92d7fe64e9fff6b2e488d40",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "38b7104fd1db0046ceed579f5dab4e62f136589c",
+        "rev": "a9858885e197f984d92d7fe64e9fff6b2e488d40",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,8 +3,8 @@
 
   inputs = 
     {
-      nixpkgs.url = "github:nixos/nixpkgs/38b7104fd1db0046ceed579f5dab4e62f136589c"; # GCC12
-      #nixpkgs.url = "github:nixos/nixpkgs/a9858885e197f984d92d7fe64e9fff6b2e488d40"; #GCC13
+      #nixpkgs.url = "github:nixos/nixpkgs/38b7104fd1db0046ceed579f5dab4e62f136589c"; # GCC12
+      nixpkgs.url = "github:nixos/nixpkgs/a9858885e197f984d92d7fe64e9fff6b2e488d40"; #GCC13
     };
 
   outputs = { self, nixpkgs, ... }:
@@ -19,7 +19,6 @@
         default = pkgs.mkShell
           {
             nativeBuildInputs = with pkgs; [
-              glibc.debug
               cmake
               vim
               pkg-config
@@ -27,16 +26,16 @@
             ];
             buildInputs = with pkgs; [
               binutils
-              gdb
               which
               gfortran
+	      gccStdenv
+              llvmPackages.openmp
               openblasCompat.dev
               hdf5-cpp.dev
-              python311Full.debug
+              python311Full
               python311Packages.numpy
               python311Packages.matplotlib
               python311Packages.tkinter
-              hotspot
             #] ++ (if system == "aarch64-darwin" then [ ] else [ gdb ]);
             ];
             

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,6 @@
               binutils
               which
               gfortran
-	      gccStdenv
               llvmPackages.openmp
               openblasCompat.dev
               hdf5-cpp.dev

--- a/install_ester.sh
+++ b/install_ester.sh
@@ -3,10 +3,10 @@ if test -d ester; then
   exit
 fi
 echo "Installing ester"
-git clone https://github.com/ester-project/ester.git
+git clone https://github.com/4D-STAR/ester.git
 cd ester
-git checkout evolution
-git apply ../numpy_dirs_and_new_gfortran.patch
+git checkout evolution_nix
+#git apply ../numpy_dirs_and_new_gfortran.patch
 mkdir build
 cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=../../install


### PR DESCRIPTION
With the updates, nix can create suitable environments for both linux(ubuntu) and macosx(M1). It clones `evolution_nix` from _4dstar/ester_ instead of `evolution` branch of _ester-project/ester_ as the former has all the necessary patches to make ester work with the above osx. 